### PR TITLE
Fix Safari extension issues

### DIFF
--- a/c0x0.com/Shared (Extension)/Resources/popup/main.js
+++ b/c0x0.com/Shared (Extension)/Resources/popup/main.js
@@ -137,7 +137,7 @@ async function createForm(){
   childElementForm.setAttribute('class', 'input-group mt-3 mb-3');
   childElementForm.innerHTML = "<div class=\"input-group-prepend\">" +
     "<span class=\"input-group-text\">Name</span></div>" +
-    "<input id=\"newalias\" \"type=\"text\" class=\"form-control bg-light text-center\" placeholder=\"description\"></div>";
+    "<input id=\"newalias\" type=\"text\" class=\"form-control bg-light text-center\" placeholder=\"description\"></div>";
   parentElement.appendChild(childElementForm);
 
   /* Append placeholder */
@@ -242,7 +242,7 @@ async function listAliasesScope(scope) {
         var childElementBody = document.createElement('div');
         childElementBody.setAttribute('class', 'card-body p-1');
         childElementBody.innerHTML = "<strong>" + safeEscape(alias.tag) + "</strong><br>" + aliasStatus +
-          "<div class=\"input-group\"><input id=\"btn" + safeEscape(alias.alias_id) + "\"type=\"text\" class=\"form-control bg-light text-center text-monospace\" readonly value=\"" + safeEscape(alias.alias) +"\">" +
+          "<div class=\"input-group\"><input id=\"btn" + safeEscape(alias.alias_id) + "\" type=\"text\" class=\"form-control bg-light text-center text-monospace\" readonly value=\"" + safeEscape(alias.alias) +"\">" +
           "<div class=\"input-group-append\"><button class=\"btn btn-primary\" type=\"button\" data-clipboard-target=\"#btn" + safeEscape(alias.alias_id) + "\">Copy</button></div></div>";
         childElement.appendChild(childElementBody);
       }

--- a/c0x0.com/c0x0.com.xcodeproj/project.pbxproj
+++ b/c0x0.com/c0x0.com.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
+                                MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -649,7 +649,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
+                                MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -815,7 +815,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+                                MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -848,7 +848,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+                                MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -884,7 +884,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+                                MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -921,7 +921,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+                                MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/c0x0.com/iOS (App)/Info.plist
+++ b/c0x0.com/iOS (App)/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SFSafariWebExtensionConverterVersion</key>
-	<string>13.4</string>
+       <string>17.0</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/c0x0.com/macOS (App)/Info.plist
+++ b/c0x0.com/macOS (App)/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>SFSafariWebExtensionConverterVersion</key>
-	<string>13.4</string>
+       <string>17.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- fix markup for create alias form
- fix alias list markup quoting
- bump converter version references to 17.0
- update macOS deployment targets for new Xcode

## Testing
- `plutil -lint -- "c0x0.com/iOS (App)/Info.plist"`
- `plutil -lint -- "c0x0.com/macOS (App)/Info.plist"`
- `plutil -lint -- "c0x0.com/macOS (Extension)/Info.plist"`
- `plutil -lint -- "c0x0.com/iOS (Extension)/Info.plist"`
- `jq . "c0x0.com/Shared (Extension)/Resources/manifest.json" > /tmp/manifest.tmp && tail -n 1 /tmp/manifest.tmp`

------
https://chatgpt.com/codex/tasks/task_e_6841daf23f688333ab382d59cb1773a8